### PR TITLE
Styles cleanup

### DIFF
--- a/src/app/adminAddresses/templates/adminAddresses.tpl.html
+++ b/src/app/adminAddresses/templates/adminAddresses.tpl.html
@@ -2,7 +2,7 @@
     <nav class="navbar navbar-default navbar-unstacked">
         <div class="container container-smooth">
             <ul class="nav navbar-nav navbar-left">
-                <ul class="breadcrumb">
+                <ul class="navbar-breadcrumb">
                     <li class="active">Admin Addresses</li>
                 </ul>
             </ul>

--- a/src/app/adminUsers/templates/adminUsers.html
+++ b/src/app/adminUsers/templates/adminUsers.html
@@ -2,7 +2,7 @@
     <nav class="navbar navbar-default navbar-unstacked">
         <div class="container container-smooth">
             <ul class="nav navbar-nav navbar-left">
-                <ul class="breadcrumb">
+                <ul class="navbar-breadcrumb">
                     <li class="active">Admin Users</li>
                 </ul>
             </ul>

--- a/src/app/buyers/templates/buyer.html
+++ b/src/app/buyers/templates/buyer.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-unstacked">
     <div class="container container-smooth">
         <ul class="nav navbar-nav navbar-left">
-            <ul class="breadcrumb">
+            <ul class="navbar-breadcrumb">
                 <!--<li><a href="#"></a></li>-->
                 <li><a href="" ui-sref="buyers">Buyers</a></li>
                 <li class="active" ui-sref="buyer">{{buyer.selectedBuyer.Name}}</li>

--- a/src/app/buyers/templates/buyers.html
+++ b/src/app/buyers/templates/buyers.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-unstacked">
     <div class="container container-smooth">
         <ul class="nav navbar-nav navbar-left">
-            <ul class="breadcrumb">
+            <ul class="navbar-breadcrumb">
                 <li class="active" ui-sref="buyers">Buyers</li>
             </ul>
         </ul>

--- a/src/app/productManagement/pricing/templates/productPricing.html
+++ b/src/app/productManagement/pricing/templates/productPricing.html
@@ -14,26 +14,26 @@
         <br>
 
         <!--==== Product Price Schedule List ====-->
-        <div class="l-price">
+        <div class="l-price-list">
             <div ng-repeat="assignment in productPricing.listAssignments"
                  ng-class="{'active':productPricing.selectedPrice.PriceSchedule.ID == assignment.PriceSchedule.ID}"
-                 class="c-price-card"
+                 class="c-price-list-item"
                  ng-click="productPricing.selectPrice(this)">
                 <!--==== Product Price Selection ====-->
 
-                <h5 class="c-price-card__info">
+                <h5 class="c-price-list-item__info">
                     {{assignment.PriceSchedule.Name}} <br>
                     <small>{{'ID: ' + assignment.PriceSchedule.ID}}</small>
                 </h5>
-                <div class="c-price-card__price">
+                <div class="c-price-list-item__price">
                     {{assignment.PriceSchedule.PriceBreaks[0].Price | currency}}
                 </div>
-                <div class="c-price-card__buyers">
+                <div class="c-price-list-item__buyers">
                     <small>Buyers</small>
                     <br>
                     {{assignment.Buyers.length}}
                 </div>
-                <div class="c-price-card__groups">
+                <div class="c-price-list-item__groups">
                     <small>Groups</small>
                     <br>
                     {{assignment.UserGroups.length}}

--- a/src/app/productManagement/pricing/templates/productPricing.html
+++ b/src/app/productManagement/pricing/templates/productPricing.html
@@ -14,29 +14,30 @@
         <br>
 
         <!--==== Product Price Schedule List ====-->
-        <div ng-repeat="assignment in productPricing.listAssignments"
-             ng-class="{'active':productPricing.selectedPrice.PriceSchedule.ID == assignment.PriceSchedule.ID}"
-             class="c-price-card"
-             ng-click="productPricing.selectPrice(this)">
-            <!--==== Product Price Selection ====-->
+        <div class="l-price">
+            <div ng-repeat="assignment in productPricing.listAssignments"
+                 ng-class="{'active':productPricing.selectedPrice.PriceSchedule.ID == assignment.PriceSchedule.ID}"
+                 class="c-price-card"
+                 ng-click="productPricing.selectPrice(this)">
+                <!--==== Product Price Selection ====-->
 
-            <div class="c-price-card__info">
-                <h5>{{assignment.PriceSchedule.Name}} <br>
+                <h5 class="c-price-card__info">
+                    {{assignment.PriceSchedule.Name}} <br>
                     <small>{{'ID: ' + assignment.PriceSchedule.ID}}</small>
                 </h5>
-            </div>
-            <div class="c-price-card__price">
-                {{assignment.PriceSchedule.PriceBreaks[0].Price | currency}}
-            </div>
-            <div class="c-price-card__buyers">
-                <small>Buyers</small>
-                <br>
-                {{assignment.Buyers.length}}
-            </div>
-            <div class="c-price-card__groups">
-                <small>Groups</small>
-                <br>
-                {{assignment.UserGroups.length}}
+                <div class="c-price-card__price">
+                    {{assignment.PriceSchedule.PriceBreaks[0].Price | currency}}
+                </div>
+                <div class="c-price-card__buyers">
+                    <small>Buyers</small>
+                    <br>
+                    {{assignment.Buyers.length}}
+                </div>
+                <div class="c-price-card__groups">
+                    <small>Groups</small>
+                    <br>
+                    {{assignment.UserGroups.length}}
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/productManagement/product/templates/productDetail.html
+++ b/src/app/productManagement/product/templates/productDetail.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-unstacked">
     <div class="container container-smooth">
         <ul class="nav navbar-nav navbar-left">
-            <ul class="breadcrumb">
+            <ul class="navbar-breadcrumb">
                 <li><a href="" ui-sref="products">All Products</a></li>
                 <li class="active">{{productDetail.productName}}</li>
             </ul>

--- a/src/app/productManagement/products/templates/productCreate.html
+++ b/src/app/productManagement/products/templates/productCreate.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default navbar-unstacked">
     <div class="container container-smooth">
         <ul class="nav navbar-nav navbar-left">
-            <ul class="breadcrumb">
+            <ul class="navbar-breadcrumb">
                 <li><a href="" ui-sref="products">All Products</a></li>
                 <li class="active">Create New Product</li>
             </ul>

--- a/src/app/productManagement/products/templates/products.html
+++ b/src/app/productManagement/products/templates/products.html
@@ -2,7 +2,7 @@
     <nav class="navbar navbar-default navbar-unstacked">
         <div class="container container-smooth">
             <ul class="nav navbar-nav navbar-left">
-                <ul class="breadcrumb">
+                <ul class="navbar-breadcrumb">
                     <li class="active">All Products</li>
                 </ul>
             </ul>

--- a/src/app/productManagement/specs/templates/productSpecs.html
+++ b/src/app/productManagement/specs/templates/productSpecs.html
@@ -4,12 +4,6 @@
 </div>
 <div class="row" ng-if="productSpecs.specs.Items.length">
     <div class="col-sm-5">
-        <script type="text/ng-template" id="specs_renderer.html">
-            <div class="tree-node tree-node-content" ng-class="{'selected-node': node.Spec.ID == productSpecs.selectedSpec.Spec.ID}">
-                <p ng-click="productSpecs.specSelected(node)">{{node.Spec.Name}}</p>
-                <i ui-tree-handle class="fa fa-reorder text-muted"></i>
-            </div>
-        </script>
         <button type="button" class="btn btn-primary" ng-click="productSpecs.createSpec(productDetail.product.ID)">
             <i class="fa fa-plus-circle" aria-hidden="true"></i>
             New Spec
@@ -17,9 +11,15 @@
         <br>
         <br>
 
+        <script type="text/ng-template" id="specs_renderer.html">
+            <div class="tree-node tree-node-content" ng-class="{'selected-node': node.Spec.ID == productSpecs.selectedSpec.Spec.ID}">
+                <p ng-click="productSpecs.specSelected(node)">{{node.Spec.Name}}</p>
+                <i ui-tree-handle class="fa fa-reorder text-muted"></i>
+            </div>
+        </script>
         <div ui-tree="productSpecs.specTreeOptions" id="spec-tree-root" data-drag-delay="200">
             <ol ui-tree-nodes ng-model="productSpecs.specs.Items">
-                <li ng-repeat="node in productSpecs.specs.Items track by $index" ui-tree-node ng-include="'specs_renderer.html'"></li>
+                <li ng-repeat="node in productSpecs.specs.Items" ui-tree-node ng-include="'specs_renderer.html'"></li>
             </ol>
         </div>
     </div>
@@ -60,6 +60,14 @@
                 <h4 class="page-header">
                     Options
                 </h4>
+
+                <button type="button" class="btn btn-primary" ng-click="productSpecs.createSpecOption()">
+                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
+                    New Option
+                </button>
+                <br>
+                <br>
+
                 <script type="text/ng-template" id="spec_options_renderer.html">
                     <div class="tree-node tree-node-content" cg-busy="node.loading">
                         <i class="fa fa-trash-o text-danger" ng-click="productSpecs.deleteSpecOption(node)"></i>
@@ -76,13 +84,6 @@
                         <i ui-tree-handle class="fa fa-reorder text-muted"></i>
                     </div>
                 </script>
-                <button type="button" class="btn btn-primary" ng-click="productSpecs.createSpecOption()">
-                    <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                    New Option
-                </button>
-                <br>
-                <br>
-
                 <div ui-tree="productSpecs.specOptionsTreeOptions" id="spec-options-tree-root" data-drag-delay="200">
                     <ol ui-tree-nodes ng-model="productSpecs.selectedSpec.Options">
                         <li ng-repeat="node in productSpecs.selectedSpec.Options" ui-tree-node ng-include="'spec_options_renderer.html'"></li>

--- a/src/app/styles/components/_navbar.less
+++ b/src/app/styles/components/_navbar.less
@@ -34,15 +34,6 @@
   }
 }
 
-// Default navbar
-.navbar-white {
-  background-color: white;
-  border-color: @gray-lighter;
-  .breadcrumb {
-    background-color:white;
-  }
-}
-
 .navbar-breadcrumb {
   .breadcrumb;
   border:none;

--- a/src/app/styles/components/_navbar.less
+++ b/src/app/styles/components/_navbar.less
@@ -43,28 +43,50 @@
   }
 }
 
-.nav {
-  .breadcrumb {
-    background-color:transparent;
-    margin: 7px 10px;
-    float:left;
-  }
-  &.navbar-left {
-    .breadcrumb {
-      &:first-child {
-        padding-left:0;
-        margin-left:0;
-      }
+.navbar-breadcrumb {
+  .breadcrumb;
+  border:none;
+  background-color:transparent;
+  padding: @navbar-padding-vertical @navbar-padding-horizontal;
+  margin:0;
+  float:left;
+  font-size:1em;
+}
+
+.navbar-left {
+  .navbar-breadcrumb {
+    &:first-child {
+      padding-left:0;
+      margin-left:0;
     }
   }
-  &.navbar-right {
-    .breadcrumb {
-      &:last-child {
-        padding-right:0;
-        margin-right:0;
-      }
+}
+.navbar-right {
+  .navbar-breadcrumb {
+    &:last-child {
+      padding-right:0;
+      margin-right:0;
     }
   }
 }
 
-@grid-float-breakpoint: 0;
+.navbar-default .nav {
+  .navbar-breadcrumb {
+    a {
+      color:@navbar-default-link-color;
+    }
+    .active {
+      color:@navbar-default-link-active-color;
+    }
+  }
+}
+.navbar-inverse .nav {
+  .navbar-breadcrumb {
+    a {
+      color:@navbar-inverse-link-color;
+    }
+    .active {
+      color:@navbar-inverse-link-active-color;
+    }
+  }
+}

--- a/src/app/styles/components/_price-card.less
+++ b/src/app/styles/components/_price-card.less
@@ -1,10 +1,10 @@
-.l-price {
+.l-price-list {
   .panel;
   .panel-default;
   border-bottom-width:0;
   overflow:hidden;
 }
-.c-price-card {
+.c-price-list-item {
   box-shadow:none;
   display:flex;
   flex-direction:row;

--- a/src/app/styles/components/_price-card.less
+++ b/src/app/styles/components/_price-card.less
@@ -1,31 +1,41 @@
+.l-price {
+  .panel;
+  .panel-default;
+  border-bottom-width:0;
+  overflow:hidden;
+}
 .c-price-card {
-  // add flex display to price card wrapper
-  // flex the product card to fill the grid item element
   box-shadow:none;
   display:flex;
-  flex-flow:row nowrap;
+  flex-direction:row;
+  flex-wrap:wrap;
   align-items:center;
-  border-bottom:1px solid @hr-border;
-  &:last-of-type {
-    margin-bottom:20px;
-  }
-
-  //.oc-flex-layout.flex-auto;
+  border-bottom:1px solid @panel-default-border;
   &__info {
+    margin-left:@padding-base-horizontal;
     flex-grow:1;
     flex-basis:35%;
+    @media(max-width:@screen-xs-max) {
+      flex-basis:50%;
+    }
   }
-  // flex the descrip to push icons to bottom of card
   &__price {
     flex:1;
-    font-size:1.4em;
+    font-weight:bold;
+    font-size:1.2em;
     color:@brand-primary;
+    padding:@padding-base-vertical @padding-base-horizontal;
   }
   &__groups,
   &__buyers {
+    font-size: 0.9em;
     flex:1;
     text-align:center;
     color:@text-muted;
+    padding:@padding-base-vertical;
+    @media(max-width:@screen-xs-max) {
+      display:none;
+    }
   }
   &.active {
     border-bottom-color:@brand-primary;

--- a/src/app/styles/components/_tree.less
+++ b/src/app/styles/components/_tree.less
@@ -18,6 +18,8 @@
 .angular-ui-tree {
   .panel;
   .panel-default;
+  border-bottom-width:0;
+  overflow:hidden;
 }
 
 .tree-node {
@@ -29,11 +31,11 @@
     border-color: @state-warning-border;
   }
   &.selected-node {
-    color:@brand-primary;
-    border-color:@brand-primary;
+    color:@link-color;
+    border-color:@link-color;
     .fa-folder,
     .fa-folder-open {
-      color:@brand-primary;
+      color:@link-color;
     }
   }
 }

--- a/src/app/styles/shame.less
+++ b/src/app/styles/shame.less
@@ -1,3 +1,5 @@
+@grid-float-breakpoint: 0; //turn off nav stacking
+
 [ui-sref],
 [ng-click]{
   cursor: pointer;


### PR DESCRIPTION
Created a new class called `.navbar-breadcrumb` that 
extends off of the `.breadcrumb` class.  Also used more
bootstrap variables such as `@navbar-default-link-color`,
`@navbar-default-link-active-color`, and `@navbar-padding-*`

Moved `@grid-float-breadkpoint:0` to `shame.less`

Removed unnecessary `.navbar-white` class from `_navbar.less`

Cleaned up some of the `_tree.less` to use more bootstrap
variables like `@link-color`

Added a `.l-price` for wrapping the `.c-price-card`. This extends
off of `.panel` & `.panel-default` similar to `.angular-ui-tree`.


